### PR TITLE
Fix zrIvinAyaka-caturthI timing: kaala -> madhyaahna, priority -> puu…

### DIFF
--- a/devatA/gaNapati/lunar_month/tithi/06/04/zrIvinAyaka-caturthI.toml
+++ b/devatA/gaNapati/lunar_month/tithi/06/04/zrIvinAyaka-caturthI.toml
@@ -27,11 +27,11 @@ shlokas = """
 [timing]
 default_to_none = true
 month_type = "lunar_month"
-priority = "paraviddha"
+priority = "puurvaviddha"
 month_number = 6
 anga_type = "tithi"
 anga_number = 4
-kaala = "अपराह्णः" # Actually madhyahna, but in if purna vyaapti is there on second day, it is on second.
+kaala = "मध्याह्नः" # jyotisha's TithiFestivalAssigner.check_vinayaka_chaturthi() overrules to day 2 when day 2 has full (puurna) vyaapti of madhyaahna, evidenced by touching day 2's aparaahna.
 jsonClass = "HinduCalendarEventTiming"
 
 [names]


### PR DESCRIPTION
…rvaviddha

The previous kaala="aparaahna", priority="paraviddha" combination wrongly assigned day 1 whenever the caturthI tithi merely began sometime within day 1's aparaahna, even when it never touched day 1's madhyaahna at all and only day 2 did. The traditional rule (presence in madhyaahna, preferring day 1 unless day 2 has full/puurna vyaapti of madhyaahna) is decided correctly by the existing puurvaviddha priority once kaala is set to the actual madhyaahna window; the day-2-full-vyaapti exception is now handled on the jyotisha side by TithiFestivalAssigner.check_vinayaka_chaturthi(), which overrules to day 2 when the tithi extends into day 2's aparaahna.