### PR TITLE
Add missing English descriptions for 17 festival events

### DIFF
--- a/general/relative_event/makara-saGkramaNa-puNyakAlaH/offset__01/indra-pUjA_or_gO-pUjA.toml
+++ b/general/relative_event/makara-saGkramaNa-puNyakAlaH/offset__01/indra-pUjA_or_gO-pUjA.toml
@@ -9,5 +9,8 @@ anchor_festival_id = "makara-saGkramaNa-puNyakAlaH"
 offset = 1
 jsonClass = "HinduCalendarEventTiming"
 
+[description]
+en = "Worship of Indra and/or cattle (Go-pūjā), performed on the day after Makara Saṅkramaṇa; corresponds to Māṭṭu Poṅkal in Tamil Nadu, when cattle are bathed, decorated and worshipped."
+
 [names]
 sa = [ "इन्द्र-पूजा/गो-पूजा",]

--- a/general/relative_event/makara-saGkramaNa-puNyakAlaH/offset__01/indra-pUjA_or_gO-pUjA.toml
+++ b/general/relative_event/makara-saGkramaNa-puNyakAlaH/offset__01/indra-pUjA_or_gO-pUjA.toml
@@ -10,7 +10,7 @@ offset = 1
 jsonClass = "HinduCalendarEventTiming"
 
 [description]
-en = "Worship of Indra and/or cattle (Go-pūjā), performed on the day after Makara Saṅkramaṇa; corresponds to Māṭṭu Poṅkal in Tamil Nadu, when cattle are bathed, decorated and worshipped."
+en = "Worship of Indra and/or cattle (Go-pūjā), performed on the day after Makara Saṅkramaṇa; corresponds to Māṭṭu Poṅgal in Tamil Nadu, when cattle are bathed, decorated and worshipped."
 
 [names]
 sa = [ "इन्द्र-पूजा/गो-पूजा",]

--- a/mahApuruSha/RShi/relative_event/kanyA-ravi-saGkramaNa-SaDazIti-puNyakAlaH/offset__-7/agastyArghyam.toml
+++ b/mahApuruSha/RShi/relative_event/kanyA-ravi-saGkramaNa-SaDazIti-puNyakAlaH/offset__-7/agastyArghyam.toml
@@ -15,5 +15,8 @@ anchor_festival_id = "kanyA-ravi-saGkramaNa-SaDazIti-puNyakAlaH"
 offset = -7
 jsonClass = "HinduCalendarEventTiming"
 
+[description]
+en = "Offering of arghya (a ceremonial water oblation) to sage Agastya, performed seven days before the Sun's transit into Kanyā (Virgo) rāśi, as prescribed in the Hemādri and Vratanirṇayakalpavallī."
+
 [names]
 sa = [ "अगस्त्यार्घ्यम्",]

--- a/tamil/relative_event/makara-saGkramaNa-puNyakAlaH/offset__-1/bhOgi.toml
+++ b/tamil/relative_event/makara-saGkramaNa-puNyakAlaH/offset__-1/bhOgi.toml
@@ -10,7 +10,7 @@ offset = -1
 jsonClass = "HinduCalendarEventTiming"
 
 [description]
-en = "Bhogi, the first day of the Tamil Poṅkal festival, observed on the day before Makara Saṅkramaṇa; old and unwanted belongings are discarded and burnt in bonfires."
+en = "Bhogi, the first day of the Tamil Poṅgal festival, observed on the day before Makara Saṅkramaṇa; old and unwanted belongings are discarded and burnt in bonfires."
 
 [names]
 ta = [ "bhOgi",]

--- a/tamil/relative_event/makara-saGkramaNa-puNyakAlaH/offset__-1/bhOgi.toml
+++ b/tamil/relative_event/makara-saGkramaNa-puNyakAlaH/offset__-1/bhOgi.toml
@@ -9,5 +9,8 @@ anchor_festival_id = "makara-saGkramaNa-puNyakAlaH"
 offset = -1
 jsonClass = "HinduCalendarEventTiming"
 
+[description]
+en = "Bhogi, the first day of the Tamil Poṅkal festival, observed on the day before Makara Saṅkramaṇa; old and unwanted belongings are discarded and burnt in bonfires."
+
 [names]
 ta = [ "bhOgi",]

--- a/tamil/relative_event/makara-saGkramaNa-puNyakAlaH/offset__01/kan2up~poGgal.toml
+++ b/tamil/relative_event/makara-saGkramaNa-puNyakAlaH/offset__01/kan2up~poGgal.toml
@@ -10,7 +10,7 @@ offset = 1
 jsonClass = "HinduCalendarEventTiming"
 
 [description]
-en = "Kāṇum Poṅkal, observed after Makara Saṅkramaṇa, when family members and friends visit one another; traditionally regarded as a concluding day of the Poṅkal festivities."
+en = "Kanu Pongal is observed on the morning after Thai Pongal, the day of Makara Saṅkramaṇa. At dawn, women and girls lay turmeric leaves in the open courtyard and set out offerings of pongal, coloured rice balls, sugarcane, etc. for crows and other birds, praying, as they do so, for the well-being and prosperity of their brothers."
 
 [names]
 ta = [ "kan2up~poGgal",]

--- a/tamil/relative_event/makara-saGkramaNa-puNyakAlaH/offset__01/kan2up~poGgal.toml
+++ b/tamil/relative_event/makara-saGkramaNa-puNyakAlaH/offset__01/kan2up~poGgal.toml
@@ -9,5 +9,8 @@ anchor_festival_id = "makara-saGkramaNa-puNyakAlaH"
 offset = 1
 jsonClass = "HinduCalendarEventTiming"
 
+[description]
+en = "Kāṇum Poṅkal, observed after Makara Saṅkramaṇa, when family members and friends visit one another; traditionally regarded as a concluding day of the Poṅkal festivities."
+
 [names]
 ta = [ "kan2up~poGgal",]

--- a/temples/Tamil/relative_event/kar2pagAmbAL–kapAlIzvarar_tirukkalyANam/offset__-3/kapAlI_tEr.toml
+++ b/temples/Tamil/relative_event/kar2pagAmbAL–kapAlIzvarar_tirukkalyANam/offset__-3/kapAlI_tEr.toml
@@ -9,6 +9,9 @@ anchor_festival_id = "kar2pagAmbAL–kapAlIzvarar_tirukkalyANam"
 offset = -3
 jsonClass = "HinduCalendarEventTiming"
 
+[description]
+en = "Tēr (temple chariot) festival — the principal car procession of Karpagāmbāḷ and Kapālīśvarar — three days before Tirukkalyāṇam."
+
 [names]
 ta = [ "kapAlI tEr",]
 sa = [ "कपालीश्वरयात्रा",]

--- a/temples/Tamil/relative_event/kar2pagAmbAL–kapAlIzvarar_tirukkalyANam/offset__-4/kapAlI_pallakku_vizhA.toml
+++ b/temples/Tamil/relative_event/kar2pagAmbAL–kapAlIzvarar_tirukkalyANam/offset__-4/kapAlI_pallakku_vizhA.toml
@@ -9,5 +9,8 @@ anchor_festival_id = "kar2pagAmbAL–kapAlIzvarar_tirukkalyANam"
 offset = -4
 jsonClass = "HinduCalendarEventTiming"
 
+[description]
+en = "Pallakku vizhā (palanquin festival) during the Kapālīśvarar temple's Paṅguni Brahmotsavam, four days before Tirukkalyāṇam."
+
 [names]
 ta = [ "kapAlI pallakku vizhA",]

--- a/temples/Tamil/relative_event/kar2pagAmbAL–kapAlIzvarar_tirukkalyANam/offset__-5/kapAlI_cavuDal_vimAn2am.toml
+++ b/temples/Tamil/relative_event/kar2pagAmbAL–kapAlIzvarar_tirukkalyANam/offset__-5/kapAlI_cavuDal_vimAn2am.toml
@@ -9,5 +9,8 @@ anchor_festival_id = "kar2pagAmbAL–kapAlIzvarar_tirukkalyANam"
 offset = -5
 jsonClass = "HinduCalendarEventTiming"
 
+[description]
+en = "Cavuḍal vimāṉam vāhana procession during the Kapālīśvarar temple's Paṅguni Brahmotsavam, five days before Tirukkalyāṇam."
+
 [names]
 ta = [ "kapAlI cavuDal vimAn2am",]

--- a/temples/Tamil/relative_event/kar2pagAmbAL–kapAlIzvarar_tirukkalyANam/offset__-7/kapAlI_bhUtaN_bhUtakI.toml
+++ b/temples/Tamil/relative_event/kar2pagAmbAL–kapAlIzvarar_tirukkalyANam/offset__-7/kapAlI_bhUtaN_bhUtakI.toml
@@ -9,5 +9,8 @@ anchor_festival_id = "kar2pagAmbAL–kapAlIzvarar_tirukkalyANam"
 offset = -7
 jsonClass = "HinduCalendarEventTiming"
 
+[description]
+en = "Bhūtaṉ-Bhūtakī procession — a folk vāhana depicting Śiva's gaṇas — during the Kapālīśvarar temple's Paṅguni Brahmotsavam, seven days before Tirukkalyāṇam."
+
 [names]
 ta = [ "kapAlI bhUtaN bhUtakI",]

--- a/temples/Tamil/relative_event/kar2pagAmbAL–kapAlIzvarar_tirukkalyANam/offset__-8/kapAlI_sUrya~candra~vaTTam.toml
+++ b/temples/Tamil/relative_event/kar2pagAmbAL–kapAlIzvarar_tirukkalyANam/offset__-8/kapAlI_sUrya~candra~vaTTam.toml
@@ -9,5 +9,8 @@ anchor_festival_id = "kar2pagAmbAL–kapAlIzvarar_tirukkalyANam"
 offset = -8
 jsonClass = "HinduCalendarEventTiming"
 
+[description]
+en = "Sūrya-candra vaṭṭam (sun-and-moon disc vāhana) procession during the Kapālīśvarar temple's Paṅguni Brahmotsavam, eight days before Tirukkalyāṇam."
+
 [names]
 ta = [ "kapAlI sUrya~candra~vaTTam",]

--- a/temples/Tamil/relative_event/kar2pagAmbAL–kapAlIzvarar_tirukkalyANam/offset__-9/kapAlI_dhvajArOhaNam.toml
+++ b/temples/Tamil/relative_event/kar2pagAmbAL–kapAlIzvarar_tirukkalyANam/offset__-9/kapAlI_dhvajArOhaNam.toml
@@ -9,6 +9,9 @@ anchor_festival_id = "kar2pagAmbAL–kapAlIzvarar_tirukkalyANam"
 offset = -9
 jsonClass = "HinduCalendarEventTiming"
 
+[description]
+en = "Dhvajārohaṇam (ceremonial flag-hoisting) marking the commencement of the Kapālīśvarar temple's Paṅguni Brahmotsavam, nine days before the Tirukkalyāṇam of Karpagāmbāḷ and Kapālīśvarar."
+
 [names]
 ta = [ "kapAlI dvajArOhaNam",]
 sa = [ "कपालीश्वर-ध्वजारोहणम्",]

--- a/temples/Tamil/relative_event/kar2pagAmbAL–kapAlIzvarar_tirukkalyANam/offset__01/kapAlI_umA-mahEzvara_darican2am.toml
+++ b/temples/Tamil/relative_event/kar2pagAmbAL–kapAlIzvarar_tirukkalyANam/offset__01/kapAlI_umA-mahEzvara_darican2am.toml
@@ -9,6 +9,9 @@ anchor_festival_id = "kar2pagAmbAL–kapAlIzvarar_tirukkalyANam"
 offset = 1
 jsonClass = "HinduCalendarEventTiming"
 
+[description]
+en = "Umā-Maheśvara darśanam, when Karpagāmbāḷ and Kapālīśvarar are presented together for devotees' darśana on the day after Tirukkalyāṇam."
+
 [names]
 ta = [ "kapAlI umA-mahEzvara darican2am",]
 sa = [ "उमा-कपालीश्वर-दर्शनम्",]

--- a/temples/Tamil/relative_event/kar2pagAmbAL–kapAlIzvarar_tirukkalyANam/offset__01/kapAlI_viDaiyAr2r2i_toDakkam.toml
+++ b/temples/Tamil/relative_event/kar2pagAmbAL–kapAlIzvarar_tirukkalyANam/offset__01/kapAlI_viDaiyAr2r2i_toDakkam.toml
@@ -9,5 +9,8 @@ anchor_festival_id = "kar2pagAmbAL–kapAlIzvarar_tirukkalyANam"
 offset = 1
 jsonClass = "HinduCalendarEventTiming"
 
+[description]
+en = "Commencement (toḍakkam) of the viḍaiyāṟṟi (valedictory send-off) rites at the Kapālīśvarar temple, beginning on the day after Tirukkalyāṇam."
+
 [names]
 ta = [ "kapAlI viDaiyAr2r2i toDakkam",]

--- a/temples/Tamil/relative_event/kar2pagAmbAL–kapAlIzvarar_tirukkalyANam/offset__11/kapAlI_viDaiyAr2r2i_nir2aivu.toml
+++ b/temples/Tamil/relative_event/kar2pagAmbAL–kapAlIzvarar_tirukkalyANam/offset__11/kapAlI_viDaiyAr2r2i_nir2aivu.toml
@@ -9,5 +9,8 @@ anchor_festival_id = "kar2pagAmbAL–kapAlIzvarar_tirukkalyANam"
 offset = 11
 jsonClass = "HinduCalendarEventTiming"
 
+[description]
+en = "Conclusion (niṟaivu) of the viḍaiyāṟṟi (valedictory send-off) rites, marking the end of the Kapālīśvarar temple's Paṅguni Brahmotsavam, eleven days after Tirukkalyāṇam."
+
 [names]
 ta = [ "kapAlI viDaiyAr2r2i nir2aivu",]

--- a/temples/Tamil/relative_event/naTarAjar_An2i_tirumaJcan2am/offset__00/cidambarE_naTarAjasya_rAjasabhAyAM_mahAbhiSEkaH.toml
+++ b/temples/Tamil/relative_event/naTarAjar_An2i_tirumaJcan2am/offset__00/cidambarE_naTarAjasya_rAjasabhAyAM_mahAbhiSEkaH.toml
@@ -15,5 +15,8 @@ anchor_festival_id = "naTarAjar_An2i_tirumaJcan2am"
 offset = 0
 jsonClass = "HinduCalendarEventTiming"
 
+[description]
+en = "Mahābhiṣeka (ceremonial bath) of Naṭarāja performed in the Rājasabhā (Chit Sabhā) of the Chidambaram temple, the culminating rite of Āṇi Tirumañjanam."
+
 [names]
 sa = [ "चिदम्बरे नटराजस्य राजसभायां महाभिषेकः",]

--- a/temples/Tamil/relative_event/taippUcam/offset__-1/kapAlI_teppOtsavam~1.toml
+++ b/temples/Tamil/relative_event/taippUcam/offset__-1/kapAlI_teppOtsavam~1.toml
@@ -9,5 +9,8 @@ anchor_festival_id = "taippUcam"
 offset = -1
 jsonClass = "HinduCalendarEventTiming"
 
+[description]
+en = "First day of the teppotsavam (float festival) at the Kapālīśvarar temple, Mylapore, held the day before Taippūcam; the deities are taken in procession on a floating raft in the temple tank."
+
 [names]
 ta = [ "kapAlI teppOtsavam",]

--- a/temples/Tamil/relative_event/taippUcam/offset__00/kapAlI_teppOtsavam~2.toml
+++ b/temples/Tamil/relative_event/taippUcam/offset__00/kapAlI_teppOtsavam~2.toml
@@ -9,5 +9,8 @@ anchor_festival_id = "taippUcam"
 offset = 0
 jsonClass = "HinduCalendarEventTiming"
 
+[description]
+en = "Second, principal day of the teppotsavam (float festival) at the Kapālīśvarar temple, Mylapore, coinciding with Taippūcam."
+
 [names]
 ta = [ "kapAlI teppOtsavam",]

--- a/temples/Tamil/relative_event/taippUcam/offset__01/kapAlI_teppOtsavam~3.toml
+++ b/temples/Tamil/relative_event/taippUcam/offset__01/kapAlI_teppOtsavam~3.toml
@@ -9,5 +9,8 @@ anchor_festival_id = "taippUcam"
 offset = 1
 jsonClass = "HinduCalendarEventTiming"
 
+[description]
+en = "Third and concluding day of the teppotsavam (float festival) at the Kapālīśvarar temple, Mylapore, held the day after Taippūcam."
+
 [names]
 ta = [ "kapAlI teppOtsavam",]


### PR DESCRIPTION
These events (Chidambaram Nataraja abhisheka, Agastya Arghyam, Bhogi, Indra/Go puja, Kanum Pongal, and the Kapaliswarar temple teppotsavam and Panguni Brahmotsavam sequence) are relative events without an anga_type, so summary.get_timing_summary() had no timing-based blurb to fall back on and no description either, triggering "No anga_type in ... or description even!!" warnings during panchaanga/ICS generation. Adding an English description for each lets the summary render properly.