### PR TITLE
Add sUrya/candra-grahaNa-varNanam description templates

### DIFF
--- a/time_focus/Eclipses/description_only/candra-grahaNa-varNanam.toml
+++ b/time_focus/Eclipses/description_only/candra-grahaNa-varNanam.toml
@@ -1,0 +1,14 @@
+default_to_none = true
+id = "candra-grahaNa-varNanam"
+tags = [ "RareDays", "Eclipses",]
+jsonClass = "HinduCalendarEvent"
+
+[timing]
+default_to_none = true
+jsonClass = "HinduCalendarEventTiming"
+
+[description]
+en = "{suffix_clause}Umbral magnitude: {magnitude} (parimāṇa ≈{parimana_angula} of the traditional 12 aṅgulas). Avoid food: {niyama_text} (from {niyama_yaamas} yaamas before the yaama of first contact, until the eclipse's end). Those with janma nakshatra `{shanti_nakshatra}` (preceding/grahaNa/succeeding), or `{anujanma_nakshatra}` (anujanma) or `{trijanma_nakshatra}` (trijanma) get ashubha phala and should consider graha-shanti next day. By rashi: `{rashi_more_ashubha}` get more ashubha phala, `{rashi_ashubha}` somewhat ashubha, `{rashi_shubha}` shubha phala. {cudamani_clause}{general_note}"
+
+[names]
+sa = [ "चन्द्रग्रहणवर्णनम्",]

--- a/time_focus/Eclipses/description_only/sUrya-grahaNa-varNanam.toml
+++ b/time_focus/Eclipses/description_only/sUrya-grahaNa-varNanam.toml
@@ -1,0 +1,14 @@
+default_to_none = true
+id = "sUrya-grahaNa-varNanam"
+tags = [ "RareDays", "Eclipses",]
+jsonClass = "HinduCalendarEvent"
+
+[timing]
+default_to_none = true
+jsonClass = "HinduCalendarEventTiming"
+
+[description]
+en = "{suffix_clause}Magnitude: {magnitude_pct}% of the solar diameter is covered (parimāṇa ≈{parimana_angula} of the traditional 12 aṅgulas). Avoid food: {niyama_text} (from {niyama_yaamas} yaamas before the yaama of first contact, until the eclipse's end). Those with janma nakshatra `{shanti_nakshatra}` (preceding/grahaNa/succeeding), or `{anujanma_nakshatra}` (anujanma) or `{trijanma_nakshatra}` (trijanma) get ashubha phala and should consider graha-shanti next day. By rashi: `{rashi_more_ashubha}` get more ashubha phala, `{rashi_ashubha}` somewhat ashubha, `{rashi_shubha}` shubha phala. {cudamani_clause}{general_note}"
+
+[names]
+sa = [ "सूर्यग्रहणवर्णनम्",]


### PR DESCRIPTION
## Summary
- Adds `sUrya-grahaNa-varNanam` and `candra-grahaNa-varNanam` under `time_focus/Eclipses/description_only/`, two Python `str.format()`-style templates holding the eclipse description prose that was previously hand-built in Python (`eclipse_description.py`'s `describe_solar_eclipse`/`describe_lunar_eclipse`): the magnitude sentence, the food-restriction (bhojana-niyama) window, and the graha-shanti nakshatra/rashi clause -- with `{placeholders}` for the values computed per-occurrence from the actual astronomical circumstances.
- No `repos.toml` change needed -- `time_focus/Eclipses` is already registered there.

## Companion change
Data-side companion to `jyotisham/jyotisha`'s branch `claude/multiple-small-fixes-rrzrgj`, which retrofits `eclipse_description.py` to the `template_description.py` render pattern (the same approach already used for the mAudhya-family templates in #24): the module now computes a plain dict of substitution fields instead of building sentences directly, and `EclipticFestivalAssigner._render_eclipse_description` looks up and `.format()`-renders these two templates (plus the existing `grahaNa-sAmAnya-niyamAH` general note) for every solar/lunar eclipse occurrence.

This also fixes a latent bug the retrofit surfaced: the graha-shanti nakshatra/rashi names were previously resolved to a fixed script (ISO) at description-construction time rather than deferred like every other backtick-quoted term, so a non-ISO render would have shown ISO-diacritic names spliced into e.g. Tamil output. The jyotisha-side change now defers this correctly.

## Test plan
- [x] Both templates parse and follow the same schema as the existing `grahaNa-sAmAnya-niyamAH.toml`/mAudhya-family templates.
- [x] Verified end-to-end against the jyotisha test suite (using a local copy of this content) that solar and lunar eclipse descriptions render correctly -- magnitude, food-restriction timing, and shanti nakshatra/rashi lists all correctly substituted and transliterated to the target script.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qpqp8TRMy7b3F93RvYvi9m)_