### PR TITLE
Add timing to 10 month/anga + weekday festivals (VARA-as-anga refactor)

### DIFF
--- a/devatA/shaiva/description_only/kArttika~sOmavAsaraH.toml
+++ b/devatA/shaiva/description_only/kArttika~sOmavAsaraH.toml
@@ -51,7 +51,7 @@ jsonClass = "HinduCalendarEvent"
 default_to_none = true
 month_type = "lunar_month"
 month_number = 8
-vara = 2
+vaara = "soma"
 jsonClass = "HinduCalendarEventTiming"
 
 [description]

--- a/devatA/shaiva/description_only/kArttika~sOmavAsaraH.toml
+++ b/devatA/shaiva/description_only/kArttika~sOmavAsaraH.toml
@@ -49,6 +49,9 @@ jsonClass = "HinduCalendarEvent"
 
 [timing]
 default_to_none = true
+month_type = "lunar_month"
+month_number = 8
+vara = 2
 jsonClass = "HinduCalendarEventTiming"
 
 [description]

--- a/tamil/description_only/ADi~veLLikkizhamai.toml
+++ b/tamil/description_only/ADi~veLLikkizhamai.toml
@@ -5,6 +5,9 @@ jsonClass = "HinduCalendarEvent"
 
 [timing]
 default_to_none = true
+month_type = "sidereal_solar_month"
+month_number = 4
+vaara = "shukra"
 jsonClass = "HinduCalendarEventTiming"
 
 [description]

--- a/tamil/description_only/AvaNi~JAyir2r2ukkizhamai.toml
+++ b/tamil/description_only/AvaNi~JAyir2r2ukkizhamai.toml
@@ -5,6 +5,9 @@ jsonClass = "HinduCalendarEvent"
 
 [timing]
 default_to_none = true
+month_type = "sidereal_solar_month"
+month_number = 5
+vaara = "bhanu"
 jsonClass = "HinduCalendarEventTiming"
 
 [description]

--- a/tamil/description_only/kArttigai~JAyir2r2ukkizhamai.toml
+++ b/tamil/description_only/kArttigai~JAyir2r2ukkizhamai.toml
@@ -5,6 +5,9 @@ jsonClass = "HinduCalendarEvent"
 
 [timing]
 default_to_none = true
+month_type = "sidereal_solar_month"
+month_number = 8
+vaara = "bhanu"
 jsonClass = "HinduCalendarEventTiming"
 
 [description]

--- a/tamil/description_only/mAci~cevvAy.toml
+++ b/tamil/description_only/mAci~cevvAy.toml
@@ -5,6 +5,9 @@ jsonClass = "HinduCalendarEvent"
 
 [timing]
 default_to_none = true
+month_type = "sidereal_solar_month"
+month_number = 11
+vaara = "mangala"
 jsonClass = "HinduCalendarEventTiming"
 
 [description]

--- a/tamil/description_only/puraTTAci~can2ikkizhamai.toml
+++ b/tamil/description_only/puraTTAci~can2ikkizhamai.toml
@@ -5,6 +5,9 @@ jsonClass = "HinduCalendarEvent"
 
 [timing]
 default_to_none = true
+month_type = "sidereal_solar_month"
+month_number = 6
+vaara = "shani"
 jsonClass = "HinduCalendarEventTiming"
 
 [description]

--- a/tamil/description_only/tai~veLLikkizhamai.toml
+++ b/tamil/description_only/tai~veLLikkizhamai.toml
@@ -5,6 +5,9 @@ jsonClass = "HinduCalendarEvent"
 
 [timing]
 default_to_none = true
+month_type = "sidereal_solar_month"
+month_number = 10
+vaara = "shukra"
 jsonClass = "HinduCalendarEventTiming"
 
 [description]

--- a/time_focus/tithi-vara-combinations/description_only/aGgArakI~caturthI.toml
+++ b/time_focus/tithi-vara-combinations/description_only/aGgArakI~caturthI.toml
@@ -14,6 +14,9 @@ jsonClass = "HinduCalendarEvent"
 
 [timing]
 default_to_none = true
+anga_type = "tithi"
+anga_number = 19
+vaara = "mangala"
 jsonClass = "HinduCalendarEventTiming"
 
 [description]

--- a/time_focus/tithi-vara-combinations/description_only/kRSNAGgAraka-caturdazI-puNyakAlaH_or_yamatarpaNam.toml
+++ b/time_focus/tithi-vara-combinations/description_only/kRSNAGgAraka-caturdazI-puNyakAlaH_or_yamatarpaNam.toml
@@ -13,6 +13,10 @@ jsonClass = "HinduCalendarEvent"
 
 [timing]
 default_to_none = true
+anga_type = "tithi"
+anga_number = 29
+vaara = "mangala"
+window = "sunrise_to_purvaahna"
 jsonClass = "HinduCalendarEventTiming"
 
 [description]

--- a/time_focus/tithi-vara-combinations/description_only/pizAcamOcanam.toml
+++ b/time_focus/tithi-vara-combinations/description_only/pizAcamOcanam.toml
@@ -11,6 +11,12 @@ jsonClass = "HinduCalendarEvent"
 
 [timing]
 default_to_none = true
+month_type = "lunar_month"
+month_number = 1
+anga_type = "tithi"
+anga_number = 29
+vaara = "mangala"
+window = "sunrise_to_purvaahna"
 jsonClass = "HinduCalendarEventTiming"
 
 [description]

--- a/time_focus/tithi-vara-combinations/description_only/sukhA~aGgArakI~caturthI.toml
+++ b/time_focus/tithi-vara-combinations/description_only/sukhA~aGgArakI~caturthI.toml
@@ -121,6 +121,9 @@ jsonClass = "HinduCalendarEvent"
 
 [timing]
 default_to_none = true
+anga_type = "tithi"
+anga_number = 4
+vaara = "mangala"
 jsonClass = "HinduCalendarEventTiming"
 
 [description]


### PR DESCRIPTION
## Summary

Companion data change for the jyotisha refactor that makes VARA (weekday) a first-class computable concept, so festivals whose date is purely a function of (month, weekday, and optionally a single anga) no longer need hand-written Python. Adds `[timing]` to 10 existing festival entries that previously had empty timing (name/description only, with the actual date computed in `VaraFestivalAssigner`):

- `kArttika~sOmavAsaraH` — lunar month 8, every Monday (`vaara = "soma"`)
- `AvaNi~JAyir2r2ukkizhamai`, `puraTTAci~can2ikkizhamai`, `kArttigai~JAyir2r2ukkizhamai`, `ADi~veLLikkizhamai`, `tai~veLLikkizhamai`, `mAci~cevvAy` — 6 solar-month + weekday Tamil festivals
- `aGgArakI~caturthI` (tithi 19) / `sukhA~aGgArakI~caturthI` (tithi 4) — both `vaara = "mangala"`
- `kRSNAGgAraka-caturdazI-puNyakAlaH_or_yamatarpaNam` / `pizAcamOcanam` (lunar month 1 only) — both tithi 29, `vaara = "mangala"`, `window = "sunrise_to_purvaahna"`

`vaara` accepts either an index (1=Sunday..7=Saturday) or a name (bhanu, soma/indu, mangala/bhauma, saumya/budha, guru, shukra/bhrigu, shani/sthira).

Each conversion was verified to produce byte-identical dates to the original hand-written Python condition over multi-year, multi-city ranges before being merged; two real pre-existing bugs were found and fixed along the way (a mod-15 variable-reuse bug mislabeling some krishna-caturthi occurrences as `sukhA~` shukla, and a double-processing bug on the jyotisha side).

## Test plan

- [x] Each rule's dates verified against the original Python condition over 6-14 year ranges (Chennai, plus London for the first)
- [x] Loaded and validated via `jyotisha_tests` (`RulesCollection`, full `Panchaanga` computation) in the companion jyotisha PR

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014PCePd69pvE74o2SzgjWA5

---
_Generated by [Claude Code](https://claude.ai/code/session_014PCePd69pvE74o2SzgjWA5)_