### PR TITLE
Fix CI: unpin exact Python patch version (3.12.13 → 3.12)

### DIFF
--- a/.github/workflows/generate_panchaangas.yml
+++ b/.github/workflows/generate_panchaangas.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.12.13]
+        python-version: ['3.12']
 #         python-version: [3.5, 3.6, 3.7, 3.8]
     steps:
     - name: Inject slug/short variables


### PR DESCRIPTION
## Summary

- CI (`Generate panchAngas` / `generate` job) has been failing on every run, including on `master` itself, since the runner image dropped Python 3.12.13 (only 3.12.14 is available now) and the workflow pinned the exact patch version. Switches to the floating minor version `'3.12'` so the workflow tracks whatever patch the runner currently ships.

This is unrelated to the just-merged #27 — confirmed by checking that master's own latest CI run failed with the identical `Version 3.12.13 with arch x64 not found` error before this fix.

## Test plan

- [x] CI on this PR should now reach the actual test/generation steps instead of failing at "Set up Python"

Co-Authored-By: Claude Sonnet 5

---
_Generated by [Claude Code](https://claude.ai/code/session_014PCePd69pvE74o2SzgjWA5)_