### PR TITLE
Add timing to padmaka-yOgaH-3 (multi-anga intersection)

### DIFF
--- a/time_focus/yoga_intersections/padmaka-yOgaH-3.toml
+++ b/time_focus/yoga_intersections/padmaka-yOgaH-3.toml
@@ -9,7 +9,16 @@ jsonClass = "HinduCalendarEvent"
 
 [timing]
 default_to_none = true
+window = "full_period"
 jsonClass = "HinduCalendarEventTiming"
+
+[[timing.intersection_groups]]
+[[timing.intersection_groups.angas]]
+anga_type = "solar_nakshatra"
+anga_number = 16
+[[timing.intersection_groups.angas]]
+anga_type = "nakshatra"
+anga_number = 3
 
 [description]
 en = "When the Sun is transiting through `vizAkhA`, and the moon, through `kRttikA`, a very special  `padmaka yOga` occurs, that is more difficult to obtain than `puSkara`."


### PR DESCRIPTION
## Summary

Follow-up to #26/#27. Adds a real `[timing]` block to `padmaka-yOgaH-3`: `intersection_groups` for SOLAR_NAKSH=16 (vizAkhA) & NAKSHATRA=3 (kRttikA), `window = "full_period"` — the simplest possible conversion of this shape, since it's a single unconditional whole-period search with no vaara or day-loop gating. Moved out of `description_only` into `time_focus/yoga_intersections`, matching the other converted intersection rules (companion code change in [jyotisham/jyotisha#197](https://github.com/jyotisham/jyotisha/pull/197)).

The other two sub-cases handled by the same source Python function (`padmaka-yOga-puNyakAlaH`, `padmaka-yOgaH-2`) are day-loop-gated/branching and stay custom Python for now.

## Test plan

- [x] Verified byte-identical to a direct `_assign_anga_intersection` call with the original intersect_list, over a 25-year range (companion jyotisha test `test_padmaka_yoga_3`)
- [x] Full `pytest jyotisha_tests/temporal` in the companion jyotisha PR passes (58 passed)

Co-Authored-By: Claude Sonnet 5

---
_Generated by [Claude Code](https://claude.ai/code/session_014PCePd69pvE74o2SzgjWA5)_