### PR TITLE
Add timing to AyuSmad-bava-saumya-saMyOgaH (multi-anga intersection)

### DIFF
--- a/time_focus/yoga_intersections/AyuSmad-bava-saumya-saMyOgaH.toml
+++ b/time_focus/yoga_intersections/AyuSmad-bava-saumya-saMyOgaH.toml
@@ -6,7 +6,19 @@ jsonClass = "HinduCalendarEvent"
 
 [timing]
 default_to_none = true
+window = "sunrise_to_sunset"
 jsonClass = "HinduCalendarEventTiming"
+
+[[timing.intersection_groups]]
+[[timing.intersection_groups.angas]]
+anga_type = "yoga"
+anga_number = 3
+[[timing.intersection_groups.angas]]
+anga_type = "karana"
+anga_number = [ 2, 9, 16, 23, 30, 37, 44, 51,]
+[[timing.intersection_groups.angas]]
+anga_type = "vaara"
+anga_number = "saumya"
 
 [description]
 en = "A rare combination of `AyuSmAn yOga, bava karaNa` and `saumyavAsara`."


### PR DESCRIPTION
## Summary

Follow-up to #26/#27/#29. Adds a real `[timing]` block to `AyuSmad-bava-saumya-saMyOgaH`: `intersection_groups` for YOGA=3 (AyuSmAn) & KARANA in `{2,9,16,23,30,37,44,51}` (the repeating bava karana slot) & `vaara="saumya"` (Wednesday), `window = "sunrise_to_sunset"`. Moved out of `description_only` into `time_focus/yoga_intersections`. Companion code change in [jyotisham/jyotisha#198](https://github.com/jyotisham/jyotisha/pull/198), which also documents a real bug found and fixed along the way (see that PR for details): `vaara` is deliberately ordered *last* among the group's angas, since ordering it first would silently widen the sunrise-to-sunset search into the following night.

## Test plan

- [x] Verified byte-identical to a direct reproduction of the original day-loop (8 separate per-karana calls per Wednesday) over a 21-year range (companion jyotisha test `test_ayushmad_bava_saumya_yoga`) — this test caught the VARA-ordering bug before it shipped
- [x] Full `pytest jyotisha_tests` in the companion jyotisha PR passes

Co-Authored-By: Claude Sonnet 5

---
_Generated by [Claude Code](https://claude.ai/code/session_014PCePd69pvE74o2SzgjWA5)_