### PR TITLE
Add timing to tripuSkara-yOgaH/dvipuSkara-yOgaH (multi-anga intersection)

### DIFF
--- a/time_focus/yoga_intersections/dvipuSkara-yOgaH~0.toml
+++ b/time_focus/yoga_intersections/dvipuSkara-yOgaH~0.toml
@@ -1,5 +1,5 @@
 default_to_none = true
-id = "dvipuSkara-yOgaH~2"
+id = "dvipuSkara-yOgaH~0"
 tags = [ "RareDays", "Combinations",]
 references_secondary = [ "SmritiMuktaPhalam Part 5, SVR",]
 jsonClass = "HinduCalendarEvent"
@@ -13,7 +13,19 @@ shlokas = """
 
 [timing]
 default_to_none = true
+window = "sunrise_to_next_sunrise"
 jsonClass = "HinduCalendarEventTiming"
+
+[[timing.intersection_groups]]
+[[timing.intersection_groups.angas]]
+anga_type = "nakshatra"
+anga_number = [ 5, 14, 23,]
+[[timing.intersection_groups.angas]]
+anga_type = "tithi"
+anga_number = [ 2, 7, 12, 17, 22, 27,]
+[[timing.intersection_groups.angas]]
+anga_type = "vaara"
+anga_number = "bhanu"
 
 [description]
 en = "When a `tripAdanakSatra` is conjoined with a `bhadrA tithi` i.e. `dvitIyA`, `saptamI` or `dvAdazI`, and this falls on a Tuesday, Sunday or Saturday, it is known as a `tripuSkara-yOgaH`. The `dvipuSkara` occurs when the `bhadrA tithi`s coincide with the same days as above, but with the `dvipAda` `nakSatra`s, which are `mRgazIrSa`, `citrA` and `dhaniSThA`. Like the `tripuSkara` which gives a three-fold multiplier for `zubha` and `azubha`, the `dvipuSkara` has a two-fold effect."

--- a/time_focus/yoga_intersections/dvipuSkara-yOgaH~2.toml
+++ b/time_focus/yoga_intersections/dvipuSkara-yOgaH~2.toml
@@ -1,5 +1,5 @@
 default_to_none = true
-id = "dvipuSkara-yOgaH~6"
+id = "dvipuSkara-yOgaH~2"
 tags = [ "RareDays", "Combinations",]
 references_secondary = [ "SmritiMuktaPhalam Part 5, SVR",]
 jsonClass = "HinduCalendarEvent"
@@ -13,7 +13,19 @@ shlokas = """
 
 [timing]
 default_to_none = true
+window = "sunrise_to_next_sunrise"
 jsonClass = "HinduCalendarEventTiming"
+
+[[timing.intersection_groups]]
+[[timing.intersection_groups.angas]]
+anga_type = "nakshatra"
+anga_number = [ 5, 14, 23,]
+[[timing.intersection_groups.angas]]
+anga_type = "tithi"
+anga_number = [ 2, 7, 12, 17, 22, 27,]
+[[timing.intersection_groups.angas]]
+anga_type = "vaara"
+anga_number = "mangala"
 
 [description]
 en = "When a `tripAdanakSatra` is conjoined with a `bhadrA tithi` i.e. `dvitIyA`, `saptamI` or `dvAdazI`, and this falls on a Tuesday, Sunday or Saturday, it is known as a `tripuSkara-yOgaH`. The `dvipuSkara` occurs when the `bhadrA tithi`s coincide with the same days as above, but with the `dvipAda` `nakSatra`s, which are `mRgazIrSa`, `citrA` and `dhaniSThA`. Like the `tripuSkara` which gives a three-fold multiplier for `zubha` and `azubha`, the `dvipuSkara` has a two-fold effect."

--- a/time_focus/yoga_intersections/dvipuSkara-yOgaH~6.toml
+++ b/time_focus/yoga_intersections/dvipuSkara-yOgaH~6.toml
@@ -1,5 +1,5 @@
 default_to_none = true
-id = "dvipuSkara-yOgaH~0"
+id = "dvipuSkara-yOgaH~6"
 tags = [ "RareDays", "Combinations",]
 references_secondary = [ "SmritiMuktaPhalam Part 5, SVR",]
 jsonClass = "HinduCalendarEvent"
@@ -13,7 +13,19 @@ shlokas = """
 
 [timing]
 default_to_none = true
+window = "sunrise_to_next_sunrise"
 jsonClass = "HinduCalendarEventTiming"
+
+[[timing.intersection_groups]]
+[[timing.intersection_groups.angas]]
+anga_type = "nakshatra"
+anga_number = [ 5, 14, 23,]
+[[timing.intersection_groups.angas]]
+anga_type = "tithi"
+anga_number = [ 2, 7, 12, 17, 22, 27,]
+[[timing.intersection_groups.angas]]
+anga_type = "vaara"
+anga_number = "shani"
 
 [description]
 en = "When a `tripAdanakSatra` is conjoined with a `bhadrA tithi` i.e. `dvitIyA`, `saptamI` or `dvAdazI`, and this falls on a Tuesday, Sunday or Saturday, it is known as a `tripuSkara-yOgaH`. The `dvipuSkara` occurs when the `bhadrA tithi`s coincide with the same days as above, but with the `dvipAda` `nakSatra`s, which are `mRgazIrSa`, `citrA` and `dhaniSThA`. Like the `tripuSkara` which gives a three-fold multiplier for `zubha` and `azubha`, the `dvipuSkara` has a two-fold effect."

--- a/time_focus/yoga_intersections/tripuSkara-yOgaH~0.toml
+++ b/time_focus/yoga_intersections/tripuSkara-yOgaH~0.toml
@@ -1,5 +1,5 @@
 default_to_none = true
-id = "tripuSkara-yOgaH~6"
+id = "tripuSkara-yOgaH~0"
 tags = [ "RareDays", "Combinations",]
 references_secondary = [ "SmritiMuktaPhalam Part 5, SVR",]
 jsonClass = "HinduCalendarEvent"
@@ -19,7 +19,19 @@ shlokas = """
 
 [timing]
 default_to_none = true
+window = "sunrise_to_next_sunrise"
 jsonClass = "HinduCalendarEventTiming"
+
+[[timing.intersection_groups]]
+[[timing.intersection_groups.angas]]
+anga_type = "nakshatra"
+anga_number = [ 3, 7, 12, 16, 21, 25,]
+[[timing.intersection_groups.angas]]
+anga_type = "tithi"
+anga_number = [ 2, 7, 12, 17, 22, 27,]
+[[timing.intersection_groups.angas]]
+anga_type = "vaara"
+anga_number = "bhanu"
 
 [description]
 en = "When a `tripAdanakSatra` is conjoined with a `bhadrA tithi` i.e. `dvitIyA`, `saptamI` or `dvAdazI`, and this falls on a Tuesday, Sunday or Saturday, it is known as a `tripuSkara-yOgaH`. When only two of these coincide, it is known as `dvipuSkara`. These are specially auspicious times, and are excluded for `aparakarma`s such as `UnamAsikazrAddham`."

--- a/time_focus/yoga_intersections/tripuSkara-yOgaH~2.toml
+++ b/time_focus/yoga_intersections/tripuSkara-yOgaH~2.toml
@@ -19,7 +19,19 @@ shlokas = """
 
 [timing]
 default_to_none = true
+window = "sunrise_to_next_sunrise"
 jsonClass = "HinduCalendarEventTiming"
+
+[[timing.intersection_groups]]
+[[timing.intersection_groups.angas]]
+anga_type = "nakshatra"
+anga_number = [ 3, 7, 12, 16, 21, 25,]
+[[timing.intersection_groups.angas]]
+anga_type = "tithi"
+anga_number = [ 2, 7, 12, 17, 22, 27,]
+[[timing.intersection_groups.angas]]
+anga_type = "vaara"
+anga_number = "mangala"
 
 [description]
 en = "When a `tripAdanakSatra` is conjoined with a `bhadrA tithi` i.e. `dvitIyA`, `saptamI` or `dvAdazI`, and this falls on a Tuesday, Sunday or Saturday, it is known as a `tripuSkara-yOgaH`. When only two of these coincide, it is known as `dvipuSkara`. These are specially auspicious times, and are excluded for `aparakarma`s such as `UnamAsikazrAddham`."

--- a/time_focus/yoga_intersections/tripuSkara-yOgaH~6.toml
+++ b/time_focus/yoga_intersections/tripuSkara-yOgaH~6.toml
@@ -1,5 +1,5 @@
 default_to_none = true
-id = "tripuSkara-yOgaH~0"
+id = "tripuSkara-yOgaH~6"
 tags = [ "RareDays", "Combinations",]
 references_secondary = [ "SmritiMuktaPhalam Part 5, SVR",]
 jsonClass = "HinduCalendarEvent"
@@ -19,7 +19,19 @@ shlokas = """
 
 [timing]
 default_to_none = true
+window = "sunrise_to_next_sunrise"
 jsonClass = "HinduCalendarEventTiming"
+
+[[timing.intersection_groups]]
+[[timing.intersection_groups.angas]]
+anga_type = "nakshatra"
+anga_number = [ 3, 7, 12, 16, 21, 25,]
+[[timing.intersection_groups.angas]]
+anga_type = "tithi"
+anga_number = [ 2, 7, 12, 17, 22, 27,]
+[[timing.intersection_groups.angas]]
+anga_type = "vaara"
+anga_number = "shani"
 
 [description]
 en = "When a `tripAdanakSatra` is conjoined with a `bhadrA tithi` i.e. `dvitIyA`, `saptamI` or `dvAdazI`, and this falls on a Tuesday, Sunday or Saturday, it is known as a `tripuSkara-yOgaH`. When only two of these coincide, it is known as `dvipuSkara`. These are specially auspicious times, and are excluded for `aparakarma`s such as `UnamAsikazrAddham`."


### PR DESCRIPTION
## Summary

Follow-up to #26/#27/#29/#30. Adds real `[timing]` blocks to the 6 `tripuSkara-yOgaH`/`dvipuSkara-yOgaH` ids (3 weekdays `~0`/`~2`/`~6` x 2 nakshatra sets): `intersection_groups` for the fixed NAKSHATRA-list (tripAda or dvipAda pada set) & TITHI-list `[2,7,12,17,22,27]` (bhadra tithis) & a single `vaara` value per id, `window = "sunrise_to_next_sunrise"`. Moved out of `description_only` into `time_focus/yoga_intersections`. Companion code change in [jyotisham/jyotisha#199](https://github.com/jyotisham/jyotisha/pull/199).

## Test plan

- [x] Verified byte-identical to a direct reproduction of the original day-loop (which resolves to at most one specific nakshatra/tithi value per day, not every list member) across all 6 ids over a 15-year range (companion jyotisha test `test_pushkara_yoga`)
- [x] Full `pytest jyotisha_tests` in the companion jyotisha PR passes

Co-Authored-By: Claude Sonnet 5

---
_Generated by [Claude Code](https://claude.ai/code/session_014PCePd69pvE74o2SzgjWA5)_