### PR TITLE
Add timing to muDavan2_muzhukku (month-transition + kaala)

### DIFF
--- a/tamil/sidereal_solar_month/day/08/01/muDavan2_muzhukku.toml
+++ b/tamil/sidereal_solar_month/day/08/01/muDavan2_muzhukku.toml
@@ -5,6 +5,11 @@ jsonClass = "HinduCalendarEvent"
 
 [timing]
 default_to_none = true
+month_type = "sidereal_solar_month"
+month_number = 8
+anga_type = "day"
+anga_number = 1
+kaala = "sunrise"
 jsonClass = "HinduCalendarEventTiming"
 
 [description]


### PR DESCRIPTION
## Summary

Follow-up to #26/#27/#29/#30/#31. Adds a real `[timing]` block to `muDavan2_muzhukku`: day 1 of sidereal_solar month 8 (Vrshcika), `kaala = "sunrise"`. This is the first festival driven by a new engine mechanism (`apply_month_transition_events`, companion code change in [jyotisham/jyotisha#200](https://github.com/jyotisham/jyotisha/pull/200)) — a day-of-month rule whose civil day is decided by comparing the month's own transition time against a kaala threshold, rather than the existing anga-based puurvaviddha machinery (which is only suited to fast-oscillating angas like tithi/nakshatra/yoga, not month-scale solar transitions).

Moved out of `description_only` into the standard `month_type/anga_type/month_number/anga_number`-indexed path, matching every other day-of-month TOML rule.

## Test plan

- [x] Verified byte-identical to a direct reproduction of the original day-loop over a 20-year range (companion jyotisha test `test_mudavan_muzhukku`) — this caught two real bugs before they shipped (see the jyotisha PR)
- [x] Full `pytest jyotisha_tests` in the companion jyotisha PR passes

Co-Authored-By: Claude Sonnet 5

---
_Generated by [Claude Code](https://claude.ai/code/session_014PCePd69pvE74o2SzgjWA5)_