### PR TITLE
Add timing to tulA-kAvErI-snAna-ArambhaH (month-transition + kaala)

### DIFF
--- a/devatA/nadI/sidereal_solar_month/day/07/01/tulA-kAvErI-snAna-ArambhaH.toml
+++ b/devatA/nadI/sidereal_solar_month/day/07/01/tulA-kAvErI-snAna-ArambhaH.toml
@@ -8,6 +8,11 @@ jsonClass = "HinduCalendarEvent"
 
 [timing]
 default_to_none = true
+month_type = "sidereal_solar_month"
+month_number = 7
+anga_type = "day"
+anga_number = 1
+kaala = "braahma"
 jsonClass = "HinduCalendarEventTiming"
 
 [description]


### PR DESCRIPTION
## Summary

Follow-up to #26/#27/#29/#30/#31/#32. Adds a real `[timing]` block to `tulA-kAvErI-snAna-ArambhaH`: day 1 of sidereal_solar month 7 (Tula), `kaala = "braahma"`. Second festival driven by `apply_month_transition_events` (same mechanism as `muDavan2_muzhukku`, companion code change in [jyotisham/jyotisha#201](https://github.com/jyotisham/jyotisha/pull/201)).

Also fixes a real bug found while converting: the original Python had a bare `return` right after the day-loop's first match, so across a multi-year computation it only ever assigned this festival **once total**, never recurring annually. Confirmed with the maintainer and fixed as part of this conversion.

Moved out of `description_only` into the standard `month_type/anga_type/month_number/anga_number`-indexed path.

## Test plan

- [x] Verified against the corrected per-year decision logic over a 20-year range, confirming it now recurs annually (≥15 occurrences) rather than just the pre-bugfix single occurrence
- [x] Full `pytest jyotisha_tests` in the companion jyotisha PR passes

Co-Authored-By: Claude Sonnet 5

---
_Generated by [Claude Code](https://claude.ai/code/session_014PCePd69pvE74o2SzgjWA5)_