### PR TITLE
Add timing to vAjapEyaphala-snAna-yOgaH, bharaNI-yamArcanA, jayantI~aSTamI (multi-anga vaara-conditioned)

### DIFF
--- a/time_focus/vaara_conditioned/bharaNI-yamArcanA.toml
+++ b/time_focus/vaara_conditioned/bharaNI-yamArcanA.toml
@@ -13,7 +13,16 @@ jsonClass = "HinduCalendarEvent"
 
 [timing]
 default_to_none = true
+vaara = "shani"
 jsonClass = "HinduCalendarEventTiming"
+
+[[timing.angas]]
+anga_type = "tithi"
+anga_number = [ 4, 19,]
+
+[[timing.angas]]
+anga_type = "nakshatra"
+anga_number = 2
 
 [description]
 en = "Bharani Nakshatram & Chaturthi tithi falling on a Saturday."

--- a/time_focus/vaara_conditioned/jayantI~aSTamI.toml
+++ b/time_focus/vaara_conditioned/jayantI~aSTamI.toml
@@ -13,7 +13,18 @@ jsonClass = "HinduCalendarEvent"
 
 [timing]
 default_to_none = true
+month_type = "lunar_month"
+month_number = 10
+window = "sunrise"
 jsonClass = "HinduCalendarEventTiming"
+
+[[timing.angas]]
+anga_type = "nakshatra"
+anga_number = 2
+
+[[timing.angas]]
+anga_type = "tithi"
+anga_number = 8
 
 [description]
 en = "`saptamI tithi` on a Sunday is as sacred as a solar eclipse. Particularly good for worshipping Surya."

--- a/time_focus/vaara_conditioned/vAjapEyaphala-snAna-yOgaH.toml
+++ b/time_focus/vaara_conditioned/vAjapEyaphala-snAna-yOgaH.toml
@@ -10,7 +10,19 @@ references_primary = [ "Dharmasindhu p.34",]
 
 [timing]
 default_to_none = true
+month_type = "lunar_month"
+month_number = 1
+vaara = "budha"
+window = "sunrise"
 jsonClass = "HinduCalendarEventTiming"
+
+[[timing.angas]]
+anga_type = "tithi"
+anga_number = 8
+
+[[timing.angas]]
+anga_type = "nakshatra"
+anga_number = 7
 
 [description]
 en = "When the asterism Punarvasu occurs on a Wednesday in Chaitra (lunar) month, on a Shukla Paksha Ashtami, one obtains the great merit of performing a Vajapeya, by performing a snana in the morning."


### PR DESCRIPTION
## Summary
- Add `[timing]` blocks to 3 rules, moving them from `description_only` into `time_focus/vaara_conditioned/`
- `vAjapEyaphala-snAna-yOgaH`: month + tithi + nakshatra (both at sunrise) + vaara
- `bharaNI-yamArcanA`: vaara + tithi (4 or 19, sunrise-to-sunset touch) + nakshatra (2, sunrise-to-sunset touch)
- `jayantI~aSTamI`: month + nakshatra + tithi (both at sunrise), no vaara — previously dead code in the Python assigner (never called), now wired up live for the first time

Paired with the companion `jyotisha` PR that extends `apply_vaara_conditioned_events` to support these shapes and retires the corresponding hand-written Python.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014PCePd69pvE74o2SzgjWA5)_