### PR TITLE
Use kaala instead of window for vaara-conditioned anga-touch checks

### DIFF
--- a/time_focus/vaara_conditioned/aGgArakI~caturthI.toml
+++ b/time_focus/vaara_conditioned/aGgArakI~caturthI.toml
@@ -17,6 +17,7 @@ default_to_none = true
 anga_type = "tithi"
 anga_number = 19
 vaara = "mangala"
+kaala = "dinamaana"
 jsonClass = "HinduCalendarEventTiming"
 
 [description]

--- a/time_focus/vaara_conditioned/bharaNI-yamArcanA.toml
+++ b/time_focus/vaara_conditioned/bharaNI-yamArcanA.toml
@@ -14,6 +14,7 @@ jsonClass = "HinduCalendarEvent"
 [timing]
 default_to_none = true
 vaara = "shani"
+kaala = "dinamaana"
 jsonClass = "HinduCalendarEventTiming"
 
 [[timing.angas]]

--- a/time_focus/vaara_conditioned/jayantI~aSTamI.toml
+++ b/time_focus/vaara_conditioned/jayantI~aSTamI.toml
@@ -15,7 +15,7 @@ jsonClass = "HinduCalendarEvent"
 default_to_none = true
 month_type = "lunar_month"
 month_number = 10
-window = "sunrise"
+kaala = "sunrise"
 jsonClass = "HinduCalendarEventTiming"
 
 [[timing.angas]]

--- a/time_focus/vaara_conditioned/kRSNAGgAraka-caturdazI-puNyakAlaH_or_yamatarpaNam.toml
+++ b/time_focus/vaara_conditioned/kRSNAGgAraka-caturdazI-puNyakAlaH_or_yamatarpaNam.toml
@@ -16,7 +16,7 @@ default_to_none = true
 anga_type = "tithi"
 anga_number = 29
 vaara = "mangala"
-window = "sunrise_to_purvaahna"
+kaala = "puurvaahna"
 jsonClass = "HinduCalendarEventTiming"
 
 [description]

--- a/time_focus/vaara_conditioned/pizAcamOcanam.toml
+++ b/time_focus/vaara_conditioned/pizAcamOcanam.toml
@@ -16,7 +16,7 @@ month_number = 1
 anga_type = "tithi"
 anga_number = 29
 vaara = "mangala"
-window = "sunrise_to_purvaahna"
+kaala = "puurvaahna"
 jsonClass = "HinduCalendarEventTiming"
 
 [description]

--- a/time_focus/vaara_conditioned/sukhA~aGgArakI~caturthI.toml
+++ b/time_focus/vaara_conditioned/sukhA~aGgArakI~caturthI.toml
@@ -124,6 +124,7 @@ default_to_none = true
 anga_type = "tithi"
 anga_number = 4
 vaara = "mangala"
+kaala = "dinamaana"
 jsonClass = "HinduCalendarEventTiming"
 
 [description]

--- a/time_focus/vaara_conditioned/vAjapEyaphala-snAna-yOgaH.toml
+++ b/time_focus/vaara_conditioned/vAjapEyaphala-snAna-yOgaH.toml
@@ -13,7 +13,7 @@ default_to_none = true
 month_type = "lunar_month"
 month_number = 1
 vaara = "budha"
-window = "sunrise"
+kaala = "sunrise"
 jsonClass = "HinduCalendarEventTiming"
 
 [[timing.angas]]


### PR DESCRIPTION
## Summary
Companion data change for the `jyotisha` PR of the same title.
- Replace `window = "sunrise"` with `kaala = "sunrise"` on `vAjapEyaphala-snAna-yOgaH` and `jayantI~aSTamI`
- Replace `window = "sunrise_to_purvaahna"` with `kaala = "puurvaahna"` on `kRSNAGgAraka-caturdazI-puNyakAlaH_or_yamatarpaNam` and `pizAcamOcanam`
- Add explicit `kaala = "dinamaana"` to `bharaNI-yamArcanA` and the two older `aGgArakI~caturthI` rules (previously relied on an implicit default, which left their auto-generated description text showing a mismatched "Sūryōdayaḥ"/sunrise label)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014PCePd69pvE74o2SzgjWA5)_