### PR TITLE
Cancel stale in-progress CI runs on the same ref to avoid gh-pages push races

### DIFF
--- a/.github/workflows/generate_panchaangas.yml
+++ b/.github/workflows/generate_panchaangas.yml
@@ -15,6 +15,14 @@ on:
         required: false
         description: 'Eg. 2023'
 
+# When multiple pushes to the same ref land close together, only the latest commit's build/deploy matters --
+# cancel any still-running older run on the same ref rather than letting it race an in-progress deploy for the
+# newer one (this workflow's `Deploy html`/`Deploy md` steps git-push-force to jyotisham/jyotisha's gh-pages/
+# generated-output branches, which can otherwise fail with "cannot lock ref" if two runs push at once).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   generate:
 


### PR DESCRIPTION
## Summary
`Deploy html`/`Deploy md` force-push to `jyotisham/jyotisha`'s `gh-pages`/`generated-output` branches. When two runs on the same ref overlap, both pushes race and the loser fails with `cannot lock ref`. Since only the latest commit's build/deploy actually matters, add a `concurrency` group so a newer run cancels an older still-running one on the same ref instead of racing it.

Note: this only serializes runs *within this repo's own workflow* — it doesn't eliminate a residual race against `jyotisha`'s own CI, which deploys to the same branches independently (GitHub Actions concurrency groups are per-repo). Companion `jyotisha` PR adds the identical guard there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014PCePd69pvE74o2SzgjWA5)_